### PR TITLE
Allow repeat pushes to staging

### DIFF
--- a/push_to_staging.sh
+++ b/push_to_staging.sh
@@ -33,4 +33,4 @@ ssh "$STAGING_SSH_HOST" "$VARS $STAGING_CURRENT_PATH/script/ci/load_staging_base
 echo "--- Pushing to staging"
 exec 5>&1
 OUTPUT="$(git push "$STAGING_REMOTE" HEAD:master --force 2>&1 |tee /dev/fd/5)"
-[[ $OUTPUT =~ "Done" ]]
+[[ $OUTPUT =~ "Done" -o $OUTPUT =~ "Everything up-to-date" ]]


### PR DESCRIPTION
Hopefully resolves the issue seen (here)[https://buildkite.com/open-food-foundation/open-food-network-pull-requests/builds/998], where an attempt to push a branch to staging twice in a row (for example when something like a configuration error (non-code error) causes the push to production to fail and you want to try again.

I suspect there may be an issue here because the `post-receive` git hook may not be triggered when everything is up to date. I'm not sure whether we care about that or not...